### PR TITLE
Helm authz flag

### DIFF
--- a/helmcharts/catena/Chart.yaml
+++ b/helmcharts/catena/Chart.yaml
@@ -4,6 +4,6 @@ description: Helm chart for running Catena examples in kubernetes
 type: application
 # Automatically updated to match the version of the application
 # if a manual update is needed, append a -X to the end of the version
-version: 0.0.19-1
+version: 0.0.20
 # Automatically updated to match the version of the application
 appVersion: "0.0.19"

--- a/helmcharts/catena/Chart.yaml
+++ b/helmcharts/catena/Chart.yaml
@@ -3,7 +3,7 @@ name: catena
 description: Helm chart for running Catena examples in kubernetes
 type: application
 # Automatically updated to match the version of the application
-# if a manual update is needed, append a .X to the end of the version
-version: 0.0.19
+# if a manual update is needed, append a -X to the end of the version
+version: 0.0.19-1
 # Automatically updated to match the version of the application
 appVersion: "0.0.19"

--- a/helmcharts/catena/templates/deployment.yaml
+++ b/helmcharts/catena/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
               value: {{ .Values.dashboard_port | quote }}
             - name: CATENA_DASHBOARD_TLS_ENABLED
               value: {{ .Values.ingress.tls.enabled | quote }}
+            {{- if .Values.container.authz }}
+            - name: CATENA_AUTHZ
+              value: "on"
+            {{- end }}
           {{- if .Values.livenessProbeEnabled }}
           livenessProbe:
             {{- include "catena.image.live" . | nindent 12 }}

--- a/helmcharts/catena/templates/deployment.yaml
+++ b/helmcharts/catena/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ include "catena.image.tag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.container.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ include "catena.service.port" . }}
@@ -59,6 +63,9 @@ spec:
             {{- if .Values.container.authz }}
             - name: CATENA_AUTHZ
               value: "on"
+            {{- end }}
+            {{- with .Values.container.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.livenessProbeEnabled }}
           livenessProbe:

--- a/helmcharts/catena/values.yaml
+++ b/helmcharts/catena/values.yaml
@@ -65,10 +65,10 @@ securityContext: {}
 container:
   # Toggle authorization enforcement on the Catena container.
   authz: false
-  # Optional extra command-line arguments appended to the container entrypoint.
+  # Additional command-line arguments passed to the container entrypoint.
   args: []
   # Additional environment variables.
-  # Example to enable authz by env var:
+  # Is a list of name/value pairs, e.g.
   # extraEnv:
   #   - name: ENV_VAR_NAME
   #     value: some_value

--- a/helmcharts/catena/values.yaml
+++ b/helmcharts/catena/values.yaml
@@ -61,6 +61,11 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Runtime settings passed directly to the Catena container.
+container:
+  # Toggle authorization enforcement on the Catena container.
+  authz: false
+
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

--- a/helmcharts/catena/values.yaml
+++ b/helmcharts/catena/values.yaml
@@ -65,6 +65,14 @@ securityContext: {}
 container:
   # Toggle authorization enforcement on the Catena container.
   authz: false
+  # Optional extra command-line arguments appended to the container entrypoint.
+  args: []
+  # Additional environment variables.
+  # Example to enable authz by env var:
+  # extraEnv:
+  #   - name: ENV_VAR_NAME
+  #     value: some_value
+  extraEnv: []
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:


### PR DESCRIPTION
Add flag to the helm chart to turn on authz mode in the catena server

```yaml
# values.yaml
container:
  authz: true

```

Also adding ability to inject any env var or args to the container with
```yaml
  args:
    - --some_arg
    - --another
    - another's value
  extraEnv:
    - name: SOME_VAR
    - value: some_value
```
So that in the future we can just turn on other catena config immediately without having to rebuild the chart.

